### PR TITLE
Revert id to previous id to prevent incompatibility in saved OBS scenes

### DIFF
--- a/source/win-spout-source.cpp
+++ b/source/win-spout-source.cpp
@@ -447,7 +447,7 @@ static obs_properties_t *win_spout_properties(void *data)
 struct obs_source_info create_spout_source_info()
 {
 	struct obs_source_info spout_source_info = {};
-	spout_source_info.id = "spout_input";
+	spout_source_info.id = "spout_capture";
 	spout_source_info.type = OBS_SOURCE_TYPE_INPUT;
 	spout_source_info.output_flags = OBS_SOURCE_VIDEO |
 					 OBS_SOURCE_CUSTOM_DRAW;


### PR DESCRIPTION
Changing the spout `id` breaks scenes with previous versions of spout-source plugin