### PR TITLE
Fix: settings window lifecycle to allow OBS system tray minimization

### DIFF
--- a/source/ui/win-spout-output-settings.cpp
+++ b/source/ui/win-spout-output-settings.cpp
@@ -14,10 +14,13 @@
 #include "../win-spout-config.h"
 #include "../win-spout.h"
 
+extern win_spout_output_settings *spout_output_settings;
+
 win_spout_output_settings::win_spout_output_settings(QWidget *parent)
 	: QDialog(parent),
 	  ui(new Ui::win_spout_output_settings)
 {
+	this->setAttribute(Qt::WA_DeleteOnClose);
 	ui->setupUi(this);
 	connect(ui->pushButton_start, SIGNAL(clicked(bool)), this, SLOT(on_start()));
 	connect(ui->pushButton_stop, SIGNAL(clicked(bool)), this, SLOT(on_stop()));
@@ -43,21 +46,10 @@ void win_spout_output_settings::save_settings()
 win_spout_output_settings::~win_spout_output_settings()
 {
 	save_settings();
+	if (spout_output_settings == this) {
+		spout_output_settings = nullptr;
+	}
 	delete ui;
-}
-
-void win_spout_output_settings::close_event(QCloseEvent *event)
-{
-	UNUSED_PARAMETER(event);
-	save_settings();
-}
-
-void win_spout_output_settings::toggle_show_hide()
-{
-	if (!isVisible())
-		setVisible(true);
-	else
-		setVisible(false);
 }
 
 void win_spout_output_settings::on_start()

--- a/source/ui/win-spout-output-settings.h
+++ b/source/ui/win-spout-output-settings.h
@@ -20,8 +20,6 @@ public:
 	explicit win_spout_output_settings(QWidget *parent = 0);
 	~win_spout_output_settings();
 	void set_started_button_state(bool started);
-	void close_event(QCloseEvent *event);
-	void toggle_show_hide();
 
 private Q_SLOTS:
 	void on_start();

--- a/source/win-spout.cpp
+++ b/source/win-spout.cpp
@@ -53,13 +53,6 @@ bool obs_module_load(void)
 	obs_register_source(&spout_source_info);
 
 	// load spout output
-	QMainWindow *main_window = (QMainWindow *)obs_frontend_get_main_window();
-
-	if (!main_window) {
-		blog(LOG_ERROR, "Can't get main window!");
-		return false;
-	}
-
 	win_spout_config *config = win_spout_config::get();
 	config->load();
 
@@ -73,11 +66,22 @@ bool obs_module_load(void)
 	QAction *menu_action = (QAction *)obs_frontend_add_tools_menu_qaction(obs_module_text("toolslabel"));
 
 	obs_frontend_push_ui_translation(obs_module_get_string);
-	spout_output_settings = new win_spout_output_settings(main_window);
 	obs_frontend_pop_ui_translation();
 
 	auto menu_cb = [] {
-		spout_output_settings->toggle_show_hide();
+		if (!spout_output_settings) {
+			QMainWindow *main_window = (QMainWindow *)obs_frontend_get_main_window();
+			if (!main_window) {
+				blog(LOG_ERROR, "Can't get main window!");
+				return;
+			}
+			spout_output_settings = new win_spout_output_settings(main_window);
+			spout_output_settings->show();
+		} else {
+			spout_output_settings->show();
+			spout_output_settings->raise();
+			spout_output_settings->activateWindow();
+		}
 	};
 	menu_action->connect(menu_action, &QAction::triggered, menu_cb);
 
@@ -94,6 +98,9 @@ bool obs_module_load(void)
 
 void obs_module_unload()
 {
+	if (spout_output_settings) {
+		delete spout_output_settings;
+	}
 	blog(LOG_INFO, "win-spout unloaded!");
 }
 


### PR DESCRIPTION
- Correctly destroy settings window using WA_DeleteOnClose and destructor cleanup.
- Simplify menu callback to focus or recreate window.

Resolves #87
Resolves #62