### PR TITLE
build: fix Windows packaging for portable installs and honour installer directory (#93)

### DIFF
--- a/.github/scripts/Package-Windows.ps1
+++ b/.github/scripts/Package-Windows.ps1
@@ -48,11 +48,15 @@ function Package {
     $ProductVersion = $BuildSpec.version
 
     $OutputName = "${ProductName}-${ProductVersion}-windows-${Target}"
+    $PortableOutputName = "${ProductName}-${ProductVersion}-windows-${Target}-portable"
+    $InstallRoot = "${ProjectRoot}/release/${Configuration}/${ProductName}"
+    $PortableRoot = "${ProjectRoot}/release/${PortableOutputName}"
 
     $RemoveArgs = @{
         ErrorAction = 'SilentlyContinue'
         Path = @(
-            "${ProjectRoot}/release/${ProductName}-*-windows-*.zip"
+            "${ProjectRoot}/release/${ProductName}-*-windows-*.zip",
+            $PortableRoot
         )
     }
 
@@ -60,12 +64,36 @@ function Package {
 
     Log-Group "Archiving ${ProductName}..."
     $CompressArgs = @{
-        Path = (Get-ChildItem -Path "${ProjectRoot}/release/${Configuration}" -Exclude "${OutputName}*.*")
+        Path = (Get-ChildItem -Path "${ProjectRoot}/release/${Configuration}" -Exclude "${OutputName}*.*", "${PortableOutputName}*.*")
         CompressionLevel = 'Optimal'
         DestinationPath = "${ProjectRoot}/release/${OutputName}.zip"
         Verbose = ($Env:CI -ne $null)
     }
     Compress-Archive -Force @CompressArgs
+
+    # Traditional portable layout: re-arrange <plugin>/bin/64bit and <plugin>/data into
+    # obs-plugins/64bit and data/obs-plugins/<plugin> so the archive can be extracted
+    # straight onto an OBS install.
+    Log-Group "Archiving ${ProductName} portable layout..."
+    $PortableBinPath = "${PortableRoot}/obs-plugins/64bit"
+    $PortableDataPath = "${PortableRoot}/data/obs-plugins/${ProductName}"
+
+    New-Item -Path $PortableBinPath -ItemType Directory -Force | Out-Null
+    New-Item -Path $PortableDataPath -ItemType Directory -Force | Out-Null
+
+    Copy-Item -Path "${InstallRoot}/bin/64bit/*" -Destination $PortableBinPath -Recurse -Force
+    if ( Test-Path "${InstallRoot}/data" ) {
+        Copy-Item -Path "${InstallRoot}/data/*" -Destination $PortableDataPath -Recurse -Force
+    }
+
+    $PortableCompressArgs = @{
+        Path = (Get-ChildItem -Path $PortableRoot)
+        CompressionLevel = 'Optimal'
+        DestinationPath = "${ProjectRoot}/release/${PortableOutputName}.zip"
+        Verbose = ($Env:CI -ne $null)
+    }
+    Compress-Archive -Force @PortableCompressArgs
+    Remove-Item -Path $PortableRoot -Recurse -Force
     Log-Group
 }
 

--- a/.github/scripts/Package-Windows.ps1
+++ b/.github/scripts/Package-Windows.ps1
@@ -62,6 +62,16 @@ function Package {
 
     Remove-Item @RemoveArgs
 
+    # The cmake install tree only contains win-spout.dll. The Spout runtime DLLs it
+    # depends on are placed elsewhere by a POST_BUILD step, so stage them into the
+    # plugin bin directory here to make both the standard and portable archives
+    # self-contained (mirrors the DLLs bundled by the NSIS installer).
+    $SpoutBinariesDir = "${ProjectRoot}/deps/Spout2/BUILD/Binaries/x64"
+    $SpoutRuntimeDlls = @('Spout.dll', 'SpoutDX.dll', 'SpoutLibrary.dll')
+    foreach ( $Dll in $SpoutRuntimeDlls ) {
+        Copy-Item -Path "${SpoutBinariesDir}/${Dll}" -Destination "${InstallRoot}/bin/64bit/${Dll}" -Force
+    }
+
     Log-Group "Archiving ${ProductName}..."
     $CompressArgs = @{
         Path = (Get-ChildItem -Path "${ProjectRoot}/release/${Configuration}" -Exclude "${OutputName}*.*", "${PortableOutputName}*.*")

--- a/.github/scripts/win-spout-installer.nsi
+++ b/.github/scripts/win-spout-installer.nsi
@@ -12,10 +12,8 @@ Unicode True
 ; Main Install settings
 Name "${APPNAMEANDVERSION}"
 InstallDirRegKey HKLM "Software\${APPNAME}" ""
-InstallDir "$COMMONPROGRAMDATA\obs-studio\plugins"
+InstallDir "$COMMONPROGRAMDATA\obs-studio\plugins\win-spout"
 OutFile "..\..\release\OBS_Spout2_Plugin_Install_v${APPVERSION}.exe"
-
-Var INSTALL_BASE_DIR
 
 ; Use compression
 SetCompressor Zlib
@@ -39,9 +37,8 @@ SetCompressor Zlib
 !insertmacro MUI_LANGUAGE "English"
 !insertmacro MUI_RESERVEFILE_LANGDLL
 Section "Spout 2 OBS Plugin" Section1
-	StrCpy $INSTALL_BASE_DIR "$COMMONPROGRAMDATA\obs-studio\plugins\win-spout"
-
-	StrCpy $InstDir "$INSTALL_BASE_DIR"
+	; Install into the $INSTDIR chosen on the directory page (default
+	; ProgramData\obs-studio\plugins\win-spout) instead of always forcing ProgramData.
 
 	; Set Section properties
 	SetOverwrite on
@@ -58,6 +55,7 @@ Section "Spout 2 OBS Plugin" Section1
 	File "..\..\data\locale\en-US.ini"
 	File "..\..\data\locale\zh-CN.ini"
 	File "..\..\data\locale\pt-BR.ini"
+	File "..\..\data\locale\es-ES.ini"
 	CreateDirectory "$SMPROGRAMS\Spout 2 OBS Plugin"
 	CreateShortCut "$SMPROGRAMS\Spout 2 OBS Plugin\Uninstall Spout2 OBS Plugin.lnk" "$INSTDIR\uninstall-spout2-plugin.exe"
 
@@ -67,7 +65,7 @@ Section -FinishSection
 
 	WriteRegStr HKLM "Software\${APPNAME}" "InstallDir" "$INSTDIR"
 	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}" "DisplayName" "${APPNAME}"
-	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}" "UninstallString" "$INSTDIR\obs-plugins\uninstall-spout2-plugin.exe"
+	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}" "UninstallString" "$INSTDIR\uninstall-spout2-plugin.exe"
 	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}" "Publisher" "OBS Spout2 Plugin"
 	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}" "HelpLink" "https://github.com/Off-World-Live/obs-spout2-source-plugin"
 	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}" "DisplayVersion" "${APPVERSION}"
@@ -105,6 +103,7 @@ Section Uninstall
 	Delete "$INSTDIR\data\locale\en-US.ini"
 	Delete "$INSTDIR\data\locale\pt-BR.ini"
 	Delete "$INSTDIR\data\locale\zh-CN.ini"
+	Delete "$INSTDIR\data\locale\es-ES.ini"
 
 	; Remove remaining directories
 	RMDir "$SMPROGRAMS\Spout 2 OBS Plugin"


### PR DESCRIPTION
**TL;DR:** Add a true-portable Windows zip (extractable onto any OBS install),
bundle the Spout runtime DLLs the plugin needs, and stop the NSIS installer from forcing `C:\ProgramData`.

## Summary

The Windows release artifacts do not work for a portable OBS install.
The zip uses a `ProgramData`-style layout, so it cannot be extracted onto an OBS install and the plugin fails to load under portable mode.
Users have had to manually recreate the traditional `obs-plugins/64bit` + `data` structure to get 1.9.0 working.
The zip is also missing the Spout runtime DLLs the plugin links against, so even when placed correctly it cannot load.
The NSIS installer ignores the directory chosen on its own directory page and always installs into `C:\ProgramData\obs-studio\plugins`.

## Changes

1. **Traditional portable zip.**
   Add a second archive `…-windows-x64-portable.zip` laid out as `obs-plugins/64bit/…` + `data/obs-plugins/win-spout/…`.
   It can be extracted straight onto any OBS install, system or portable.
2. **Bundle Spout runtime DLLs.**
   Stage `Spout.dll`, `SpoutDX.dll` and `SpoutLibrary.dll` into the plugin bin directory before archiving, so both the standard and portable zips are self-contained.
   The NSIS installer already bundled these directly.
3. **Installer honours the chosen directory.**
   Remove the hard-coded `StrCpy $InstDir` override that forced `ProgramData`, and default the directory page to `…\plugins\win-spout`.
   Fix the uninstaller registry path so it matches `WriteUninstaller`, and add the missing `es-ES` locale to install/uninstall.

## Issues covered

- Closes #93 — installer always installs into `C:\ProgramData\obs-studio\plugins`.
- Addresses #95 — the release zip/installer folder structure is wrong for the OBS portable version.
- Addresses #85 — portable users had to mimic the traditional folder structure by hand; the portable zip now ships it.
- Partially addresses #88 — the portable zip loads under OBS portable mode.
  The installer now honours the chosen directory, but does not yet auto-detect an existing OBS install path (possible follow-up).

## Testing

Built with the packaging script and deployed the portable zip onto a portable OBS 32.1.2 install.
The plugin loads with the bundled Spout DLLs and the locale files resolve.
Both archives verified to contain `win-spout.dll` + the three Spout runtime DLLs + all four locale files.
