### PR TITLE
feat: opt-in continuous filter broadcast and fix filter destroy crash (#97)

### DIFF
--- a/source/ui/win-spout-output-settings.cpp
+++ b/source/ui/win-spout-output-settings.cpp
@@ -28,6 +28,7 @@ win_spout_output_settings::win_spout_output_settings(QWidget *parent)
 	win_spout_config *config = win_spout_config::get();
 
 	ui->checkBox_auto->setChecked(config->auto_start);
+	ui->checkBox_continuous->setChecked(config->continuous_broadcast);
 	ui->lineEdit_spoutname->setText(config->spout_output_name);
 
 	set_started_button_state(true);
@@ -39,6 +40,7 @@ void win_spout_output_settings::save_settings()
 {
 	win_spout_config *config = win_spout_config::get();
 	config->auto_start = ui->checkBox_auto->isChecked();
+	config->continuous_broadcast = ui->checkBox_continuous->isChecked();
 	config->spout_output_name = ui->lineEdit_spoutname->text();
 	win_spout_config::get()->save();
 }

--- a/source/ui/win-spout-output-settings.ui
+++ b/source/ui/win-spout-output-settings.ui
@@ -60,6 +60,22 @@
 					</widget>
 				</item>
 				<item>
+					<widget class="QCheckBox" name="checkBox_continuous">
+						<property name="toolTip">
+							<string>When enabled, Spout output filters broadcast continuously, even when their source is not in the active scene.
+
+This registers the sender right after a cold start, so receivers see it without opening the filter.
+
+The cost is some extra GPU for hidden sources.
+
+When disabled, the previous behaviour is kept: a filter only sends while its source is being rendered.</string>
+						</property>
+						<property name="text">
+							<string>Continuous filter broadcast</string>
+						</property>
+					</widget>
+				</item>
+				<item>
 					<layout class="QHBoxLayout" name="horizontalLayout">
 						<item>
 							<layout class="QVBoxLayout" name="verticalLayout_2">

--- a/source/win-spout-config.cpp
+++ b/source/win-spout-config.cpp
@@ -15,10 +15,11 @@
 #define SECTION_NAME "win_spout"
 #define PARAM_AUTO_START "auto_start"
 #define PARAM_SPOUT_OUTPUT_NAME "spout_output_name"
+#define PARAM_CONTINUOUS_BROADCAST "continuous_broadcast"
 
 win_spout_config *win_spout_config::_instance = nullptr;
 
-win_spout_config::win_spout_config() : auto_start(false), spout_output_name("OBS_Spout")
+win_spout_config::win_spout_config() : auto_start(false), spout_output_name("OBS_Spout"), continuous_broadcast(false)
 {
 	config_t *obs_config = obs_frontend_get_user_config();
 
@@ -26,6 +27,7 @@ win_spout_config::win_spout_config() : auto_start(false), spout_output_name("OBS
 		config_set_default_bool(obs_config, SECTION_NAME, PARAM_AUTO_START, auto_start);
 		config_set_default_string(obs_config, SECTION_NAME, PARAM_SPOUT_OUTPUT_NAME,
 					  spout_output_name.toUtf8().constData());
+		config_set_default_bool(obs_config, SECTION_NAME, PARAM_CONTINUOUS_BROADCAST, continuous_broadcast);
 	}
 }
 
@@ -35,6 +37,7 @@ void win_spout_config::load()
 	if (obs_config) {
 		auto_start = config_get_bool(obs_config, SECTION_NAME, PARAM_AUTO_START);
 		spout_output_name = config_get_string(obs_config, SECTION_NAME, PARAM_SPOUT_OUTPUT_NAME);
+		continuous_broadcast = config_get_bool(obs_config, SECTION_NAME, PARAM_CONTINUOUS_BROADCAST);
 	}
 }
 
@@ -45,6 +48,7 @@ void win_spout_config::save()
 		config_set_bool(obs_config, SECTION_NAME, PARAM_AUTO_START, auto_start);
 		config_set_string(obs_config, SECTION_NAME, PARAM_SPOUT_OUTPUT_NAME,
 				  spout_output_name.toUtf8().constData());
+		config_set_bool(obs_config, SECTION_NAME, PARAM_CONTINUOUS_BROADCAST, continuous_broadcast);
 		config_save(obs_config);
 	}
 }

--- a/source/win-spout-config.h
+++ b/source/win-spout-config.h
@@ -10,6 +10,8 @@
 #ifndef WINSPOUTCONFIG_H
 #define WINSPOUTCONFIG_H
 
+#include <atomic>
+
 #include <QString>
 #include <obs-module.h>
 
@@ -22,6 +24,12 @@ public:
 
 	bool auto_start;
 	QString spout_output_name;
+	// Continuous broadcast: when enabled, Spout output filters ignore whether their
+	// source is in the active scene, registering the sender and broadcasting from a
+	// cold start. When disabled the previous behaviour is kept (send only while the
+	// source is being rendered). Default off. Atomic because the render thread reads
+	// it every frame while the settings dialog writes it from the UI thread.
+	std::atomic<bool> continuous_broadcast;
 
 private:
 	static win_spout_config *_instance;

--- a/source/win-spout-filter.cpp
+++ b/source/win-spout-filter.cpp
@@ -13,6 +13,7 @@
 #include <media-io/video-frame.h>
 
 #include "SpoutDX.h"
+#include "win-spout-config.h"
 
 #define FILTER_PROP_NAME "spout_filter_name"
 
@@ -26,7 +27,6 @@ struct win_spout_filter {
 	// [SHARED]
 	spoutDX *filter_sender; // owned by the filter
 	obs_source_t *source_context;
-	const char *sender_name; // owned by obs
 
 	// [RENDER] After creation, only accessed on render thread
 	gs_texrender_t *texrender_curr;		// owned by filter
@@ -117,15 +117,29 @@ void win_spout_offscreen_render(void *data, uint32_t cx, uint32_t cy)
 	UNUSED_PARAMETER(cy);
 	struct win_spout_filter *context = (win_spout_filter *)data;
 
-	// We check if video_render has been called since the last offscreen_render
-	if (!context->is_active) {
+	// Continuous broadcast: ignore whether the source is in the active scene and keep
+	// rendering/broadcasting as long as the filter is enabled, so the sender registers
+	// right after a cold start (fixes receivers not seeing the signal). When off, keep
+	// the previous behaviour: send only when video_render has set is_active (source
+	// drawn). Default off.
+	const bool continuous = win_spout_config::get()->continuous_broadcast;
+
+	// Never broadcast while the filter is disabled, in either mode.
+	if (!obs_source_enabled(context->source_context)) {
+		context->is_active = false;
+		return;
+	}
+
+	if (!continuous && !context->is_active) {
 		return;
 	}
 	context->is_active = false;
 
 	if (!init_on_render_thread(context)) {
-		blog(LOG_ERROR, "Failed to create DX11 context for spout filter!");
-		win_spout_filter_destroy(context);
+		// The graphics device may not be ready during early cold start; just log and
+		// retry next frame. Never destroy context on the render thread here: OBS still
+		// holds this pointer and freeing it would crash (see #97).
+		blog(LOG_ERROR, "Failed to init DX11 for spout filter, will retry next frame");
 		return;
 	}
 
@@ -146,6 +160,11 @@ void win_spout_offscreen_render(void *data, uint32_t cx, uint32_t cy)
 
 	uint32_t width = obs_source_get_base_width(target);
 	uint32_t height = obs_source_get_base_height(target);
+
+	// Skip this frame when the size is invalid (the source may not be ready yet in
+	// continuous mode) to avoid operating on a zero-sized texture.
+	if (width == 0 || height == 0)
+		return;
 
 	// Render the target to an intemediate format in sRGB-aware format
 	gs_texrender_reset(texrender_intermediate);
@@ -241,7 +260,6 @@ void win_spout_filter_update(void *data, obs_data_t *settings)
 	pthread_mutex_lock(&context->mutex);
 
 	context->filter_sender->ReleaseSender();
-	context->sender_name = sender_name;
 	context->filter_sender->SetSenderName(sender_name);
 
 	pthread_mutex_unlock(&context->mutex);
@@ -255,7 +273,6 @@ void *win_spout_filter_create(obs_data_t *settings, obs_source_t *source)
 	// Despite bzalloc I still want to at least initialise pointer fields
 	context->filter_sender = nullptr;
 	context->source_context = nullptr;
-	context->sender_name = nullptr;
 	context->texrender_curr = nullptr;
 	context->texrender_prev = nullptr;
 	context->texrender_intermediate = nullptr;
@@ -271,8 +288,6 @@ void *win_spout_filter_create(obs_data_t *settings, obs_source_t *source)
 	}
 
 	context->source_context = source;
-
-	context->sender_name = obs_data_get_string(settings, FILTER_PROP_NAME);
 
 	context->filter_sender = new spoutDX;
 


### PR DESCRIPTION
**TL;DR:** Add an opt-in "Continuous filter broadcast" toggle (default off) so a filter's Spout sender registers reliably after an OBS restart, and remove a render-thread self-destroy that can crash.

## Summary

Two reliability issues with Spout output filters.
After an OBS restart (or scene-collection import) a filter's Spout sender is not registered until its parent becomes active; users must open the filter and click "Change Spout Name" to bring the feed back.
The filter can also attempt to destroy itself from the render thread, which risks a crash.

## Changes

1. **Opt-in "Continuous filter broadcast".**
   A new global toggle in *Tools ▸ Spout Output Settings* (config key `continuous_broadcast`, `std::atomic<bool>`), default off.
   When off, behaviour is unchanged like before: a filter broadcasts only while its parent is active.
   When on, filters keep broadcasting regardless of active/showing state, so the sender registers immediately on cold start.
   Kept opt-in so existing workflows are unaffected.
2. **Remove the render-thread self-destroy.**
   The render callback no longer calls `win_spout_filter_destroy` on the context; it logs and returns instead.
   It also guards a zero-size render target and drops a dangling `sender_name` field.

## Issues covered

- Closes #97 — crash risk: plugin cannot destroy itself.
- Addresses #36 and #79 — enabling "Continuous filter broadcast" makes the sender feed start automatically after restart.
  Left opt-in rather than changing the default behaviour.

## Testing

On OBS 32.1.2 the toggle appears and defaults to off.
With it enabled, a filter's sender re-registers reliably across full OBS restarts without manual intervention.
With it disabled, the previous on-active behaviour is preserved.
